### PR TITLE
Make this debugOnly

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,9 +1,10 @@
 Package.describe({
   name: 'tmeasday:check-npm-versions',
-  version: '0.3.1',
+  version: '0.3.2',
   summary: 'Check that required npm packages are installed at the app level',
   git: 'https://github.com/tmeasday/check-npm-versions.git',
-  documentation: 'README.md'
+  documentation: 'README.md',
+  debugOnly: true
 });
 
 Npm.depends({'semver': '5.1.0'});


### PR DESCRIPTION
Since one should be handling package dependencies before production, I've made this debugOnly to lighten client side load a bit.