### PR TITLE
Publish type definitions with package

### DIFF
--- a/package-types.json
+++ b/package-types.json
@@ -1,0 +1,3 @@
+{
+  "typesEntry": "./check-npm-versions.ts"
+}

--- a/package.js
+++ b/package.js
@@ -12,5 +12,6 @@ Npm.depends({ semver: '6.3.0' }); // 7.x versions are incompatible with Internet
 Package.onUse(function (api) {
   api.versionsFrom('2.0');
   api.use('typescript');
+  api.use('zodern:types@1.0.7');
   api.mainModule('check-npm-versions.ts');
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/Meteor-Community-Packages/check-npm-versions#readme",
   "scripts": {
     "lint": "eslint --fix ./**/*.ts",
-    "publish-release": "rimraf ./node_modules && meteor publish && meteor npm i --only=dev",
+    "publish-release": "meteor publish",
     "pre-commit": "tsc --noEmit && lint-staged",
     "prepare": "husky install"
   },


### PR DESCRIPTION
Sets up [zodern:types](https://packosphere.com/zodern/types). When the package is published, type definitions will be automatically generated. It also handles deleting npm dev dependencies, and re-installing them after the package is published.