### PR TITLE
ci: add testsuite workflow

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -1,0 +1,33 @@
+# the test suite runs the tests (headless, server+client) for multiple Meteor releases
+name: Test suite
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  lint:
+    name: Javascript standard lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-20-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-20-
+
+      - run: |
+          npm ci
+          npm run lint
+          npm run pre-commit


### PR DESCRIPTION
This adds a minimal testsuite to our ci, checking lint and tsc lint. Note that lint and tsc are updated in #46 and are expected to fail for this PR.